### PR TITLE
Problem: StreamUnordered::push naming

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "streamunordered"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ required amount of work needed to coordinate large numbers of streams.
 
 When a `StreamUnordered` is first created, it does not contain any streams. Calling `poll` in
 this state will result in `Ok(Async::Ready(None))` to be returned. Streams are submitted to the
-set using `push`; however, the stream will **not** be polled at this point. `StreamUnordered`
+set using `push_front`; however, the stream will **not** be polled at this point. `StreamUnordered`
 will only poll managed streams when `StreamUnordered::poll` is called. As such, it is important
 to call `poll` after pushing new streams.
 


### PR DESCRIPTION
By analogy with `Vec::push` it suggests that streams are append to the
end of the list. However, if you use `iter_mut()` you'll see that
streams are iterated over in reverse order.

Upon reading internal comments, it became clear that `StreamUnordered`
is backed with linked lists and inserts new streams at the head.

Solution: rename `push` to `push_front` and deprecate `push`
(naming is by analogy with `VecDeque`)

Bumps up the version to 0.6.0

---

The PR is suggestion, I am open for a discussion to see if my concern warrants this change. I decided to make this suggestion after spending two hours trying to figure why my streams are being added in reverse (they are activated by their tokens in my container stream, thus ordering is important).

P.S. Thanks for this amazing crate!