### PR TITLE
Immutable iterator + iterate with token

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -13,8 +13,6 @@ pub struct IterPinMutWithToken<'a, S> {
 }
 
 /// Mutable iterator over all streams in the unordered set.
-///
-// Unfortunately, this ended up in the public API so remains to maintain backwards compatibility
 #[derive(Debug)]
 pub struct IterPinMut<'a, S>(pub(super) IterPinMutWithToken<'a, S>);
 
@@ -114,9 +112,8 @@ impl<'a, S> Iterator for IterWithToken<'a, S> {
             return None;
         }
         unsafe {
-            let task = &*self.task;
-            let id = (*task).id;
-            let stream = (*task.stream.get()).as_ref().unwrap();
+            let id = (*self.task).id;
+            let stream = (*(*self.task).stream.get()).as_ref().unwrap();
 
             // Relaxed ordering can be used since acquire ordering when
             // `head_all` was initially read for this iterator implies acquire

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ use alloc::sync::{Arc, Weak};
 use core::cell::UnsafeCell;
 use core::fmt::{self, Debug};
 use core::iter::FromIterator;
+use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Index, IndexMut};
 use core::pin::Pin;
@@ -50,7 +51,6 @@ use core::sync::atomic::{AtomicBool, AtomicPtr};
 use futures_core::stream::{FusedStream, Stream};
 use futures_core::task::{Context, Poll};
 use futures_util::task::{ArcWake, AtomicWaker};
-use std::marker::PhantomData;
 
 mod abort;
 

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,0 +1,42 @@
+use std::{
+    future::Future,
+    pin::{pin, Pin},
+    task::{Context, Poll},
+};
+
+use futures_util::stream;
+use streamunordered::StreamUnordered;
+
+// An `async move { i }` causes unpin issues with `iter_mut` and `iter_mut_with_token`.
+pub struct UnpinFuture(usize);
+
+impl Future for UnpinFuture {
+    type Output = usize;
+
+    fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Ready(self.0)
+    }
+}
+
+#[test]
+fn iter_methods() {
+    let mut streams = StreamUnordered::new();
+    for i in 0..5 {
+        streams.insert(stream::once(UnpinFuture(i)));
+    }
+
+    let result: (Vec<_>, Vec<_>) = streams.iter_with_token().unzip();
+    assert_eq!(result.1, vec![5, 4, 3, 2, 1]);
+
+    assert_eq!(streams.iter_mut().len(), 5);
+
+    let result: (Vec<_>, Vec<_>) = streams.iter_mut_with_token().unzip();
+    assert_eq!(result.1, vec![5, 4, 3, 2, 1]);
+
+    let mut streams = pin!(streams);
+
+    assert_eq!(streams.as_mut().iter_pin_mut().len(), 5);
+
+    let result: (Vec<_>, Vec<_>) = streams.iter_pin_mut_with_token().unzip();
+    assert_eq!(result.1, vec![5, 4, 3, 2, 1]);
+}

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,28 +1,13 @@
-use std::{
-    future::Future,
-    pin::{pin, Pin},
-    task::{Context, Poll},
-};
+use std::{future::ready, pin::pin};
 
 use futures_util::stream;
 use streamunordered::StreamUnordered;
-
-// An `async move { i }` causes unpin issues with `iter_mut` and `iter_mut_with_token`.
-pub struct UnpinFuture(usize);
-
-impl Future for UnpinFuture {
-    type Output = usize;
-
-    fn poll(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
-        Poll::Ready(self.0)
-    }
-}
 
 #[test]
 fn iter_methods() {
     let mut streams = StreamUnordered::new();
     for i in 0..5 {
-        streams.insert(stream::once(UnpinFuture(i)));
+        streams.insert(stream::once(ready(i)));
     }
 
     let mut result: (Vec<_>, Vec<_>) = streams.iter_with_token().unzip();

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -25,18 +25,21 @@ fn iter_methods() {
         streams.insert(stream::once(UnpinFuture(i)));
     }
 
-    let result: (Vec<_>, Vec<_>) = streams.iter_with_token().unzip();
-    assert_eq!(result.1, vec![5, 4, 3, 2, 1]);
+    let mut result: (Vec<_>, Vec<_>) = streams.iter_with_token().unzip();
+    result.1.sort(); // We sort as order is not guaranteed.
+    assert_eq!(result.1, vec![1, 2, 3, 4, 5]);
 
     assert_eq!(streams.iter_mut().len(), 5);
 
-    let result: (Vec<_>, Vec<_>) = streams.iter_mut_with_token().unzip();
-    assert_eq!(result.1, vec![5, 4, 3, 2, 1]);
+    let mut result: (Vec<_>, Vec<_>) = streams.iter_mut_with_token().unzip();
+    result.1.sort(); // We sort as order is not guaranteed.
+    assert_eq!(result.1, vec![1, 2, 3, 4, 5]);
 
     let mut streams = pin!(streams);
 
     assert_eq!(streams.as_mut().iter_pin_mut().len(), 5);
 
-    let result: (Vec<_>, Vec<_>) = streams.iter_pin_mut_with_token().unzip();
-    assert_eq!(result.1, vec![5, 4, 3, 2, 1]);
+    let mut result: (Vec<_>, Vec<_>) = streams.iter_pin_mut_with_token().unzip();
+    result.1.sort(); // We sort as order is not guaranteed.
+    assert_eq!(result.1, vec![1, 2, 3, 4, 5]);
 }

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,4 +1,4 @@
-use async_bincode::*;
+use async_bincode::{AsyncBincodeStream, AsyncDestination};
 use futures::prelude::*;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::future::Future;


### PR DESCRIPTION
This PR makes two changes:
 - Exposes the existing `Iter` and `IterPinRef` via the methods `StreamUnordered::iter` and `StreamUnordered::iter_pin`
 - Changes `Iter` and `IterPinRef`'s `Iterator::Item` type to return `(usize, _)`. The `usize` being the token of the stream.

Changing the `Item` type of an existing type would be a breaking change but as far as I can tell these types were incapable of being constructed as the fields are private and no methods I could see returned it constructed hence this change shouldn't be breaking.

I attempted an implementation for `StreamUnordered::iter_pin` but it's way outta my depth so this PR **is missing it's implementation.** I apologize for it not being functional but I really don't know what to do, any pointers would be appreciated and I can give it another shot.

## Use case

I am working on a project that queues many streams into a `StreamUnordered` that are related to a single connection (effectively a websocket). When this connection is closed I need to be able to clear all active streams so it would be useful if something like the following was possible:

```rust
let streams = StreamUnordered::new();

// Push some streams

// Remove all streams -> collected up the tokens to avoid having a mutable and immutable reference at the same time.
for id in streams.iter().map(|(token, stream)| token).collect::<Vec<_>>() {
    streams.remove(id);
}
```

Considerations:
 - It may make sense to expose the token in a similar fashion with the mutable iterators although this would be a breaking change. I am happy to update the PR if you have guidance on how to handle this.

This would also close #4.